### PR TITLE
fix typo in derived parameters

### DIFF
--- a/analysis_engine/derived_parameters.py
+++ b/analysis_engine/derived_parameters.py
@@ -4941,7 +4941,7 @@ class CoordinatesSmoothed(object):
 
             if approach.type == 'LANDING':
                 runway = approach.landing_runway
-            elif approach.type == 'GO AROUND':
+            elif approach.type == 'GO_AROUND':
                 runway = approach.approach_runway
             else:
                 raise 'unfamiliar approach type'


### PR DESCRIPTION
You can see that GO_ARROUND is the correct name. 