### PR TITLE
Add the missing parameters to WRAPPING_PARAMS 

### DIFF
--- a/analysis_engine/settings.py
+++ b/analysis_engine/settings.py
@@ -131,6 +131,8 @@ WRAPPING_PARAMS = (
     'IRU Heading (R)',
     # Longitude
     'Longitude',  # When flying past the Bering Sea (-180 to +180)
+    'Longitude (1)',
+    'Longitude (2)',
     'Longitude (FO)',
     'Longitude (Capt)',
     'Longitude Recorded',


### PR DESCRIPTION
Fixes masking of longitude, longitude prepared and longitude smoothed when crossing 180th meridian.

Validation occurred on 'Longitude (1)' and 'Longitude (2)', but neither were in WRAPPING_PARAMS, so they weren't straightened before the rate of change check was run (thus masking the flight after crossing -180degrees).
Before - masked after crossing 180 degrees
![flight13935082-pre-fix](https://user-images.githubusercontent.com/35376158/40107202-846da540-58ef-11e8-8faf-7529f4c3b0a0.png)
Hdf5 view after fix - longitude smoothed no longer masked after the crossing
![fji-flight-after](https://user-images.githubusercontent.com/35376158/40107210-89769650-58ef-11e8-9ca8-c3f96870b931.png)
