### PR TITLE
Exclude single sample instances from Master Warning kpvs

### DIFF
--- a/analysis_engine/key_point_values.py
+++ b/analysis_engine/key_point_values.py
@@ -17446,15 +17446,18 @@ class MasterWarningDuration(KeyPointValueNode):
                family=A('Family'),
                airborne=S('Airborne')):
         
+        # min duration is a greater than or equal to operator
+        single_sample = (1/warning.hz) + 1
+
         if family and family.value in 'AW139':
-            self.create_kpvs_where(warning.array == 'Warning', warning.hz, phase=airborne)
+            self.create_kpvs_where(warning.array == 'Warning', warning.hz, phase=airborne, min_duration=single_sample)
         
         elif any_engine:
             self.create_kpvs_where(np.ma.logical_and(warning.array == 'Warning',
                                                      any_engine.array == 'Running'),
-                                   warning.hz)
+                                   warning.hz, min_duration=single_sample)
         else:
-            self.create_kpvs_where(warning.array == 'Warning', warning.hz)
+            self.create_kpvs_where(warning.array == 'Warning', warning.hz, min_duration=single_sample)
 
 
 class MasterWarningDuringTakeoffDuration(KeyPointValueNode):
@@ -17468,8 +17471,11 @@ class MasterWarningDuringTakeoffDuration(KeyPointValueNode):
                warning=M('Master Warning'),
                takeoff_rolls=S('Takeoff Roll Or Rejected Takeoff')):
 
+        # min duration is a greater than or equal to operator
+        single_sample = (1/warning.hz) + 1
+
         self.create_kpvs_where(warning.array == 'Warning',
-                               warning.hz, phase=takeoff_rolls)
+                               warning.hz, phase=takeoff_rolls, min_duration=single_sample)
 
 
 class MasterCautionDuringTakeoffDuration(KeyPointValueNode):

--- a/tests/key_point_value_test.py
+++ b/tests/key_point_value_test.py
@@ -20668,7 +20668,6 @@ class TestMasterWarningDuration(unittest.TestCase, NodeTest):
         self.assertEqual(len(warn), 0)
         
     def test_derive_AW139(self):
-        
         master_warning = M(array=np.ma.array([0,0,0,1,1,1,1,1,1,1,0,0]),
                            values_mapping={1: 'Warning'})        
         family = A('Family', value='AW139')
@@ -20678,7 +20677,19 @@ class TestMasterWarningDuration(unittest.TestCase, NodeTest):
         self.assertEqual(len(node), 1)
         self.assertEqual(node[0].index, 5)
         self.assertEqual(node[0].value, 3)
-        
+
+    def test_derive_single_sample(self):
+        node = MasterWarningDuration()
+        master_warning = M(array=np.ma.array([0,1]*10),
+                           values_mapping={1: 'Warning'},
+                           )
+        engine_running = M(array=np.ma.array([1]*20),
+                           values_mapping={1:'Running'},
+                           )
+        node.derive(master_warning, engine_running)
+        self.assertEqual(len(node), 0)
+
+
 class TestEngRunningDuration(unittest.TestCase):
 
     def test_can_operate(self):
@@ -20794,9 +20805,30 @@ class TestMasterWarningDuringTakeoffDuration(unittest.TestCase, NodeTest):
         self.operational_combinations = [('Master Warning',
                                           'Takeoff Roll Or Rejected Takeoff')]
 
-    @unittest.skip('Test Not Implemented')
     def test_derive(self):
-        self.assertTrue(False, msg='Test not implemented.')
+        node = self.node_class()
+        takeoff_rolls = buildsection('Takeoff Roll Or Rejected Takeoff', 5, 15)
+        master_warning = M(array=np.ma.array([0, 1, 1, 1, 0,
+                                              0, 0, 0, 0, 0,
+                                              0, 1, 1, 1, 0,
+                                              0, 0, 0, 0, 0,
+                                              0, 1, 1, 1, 0,
+                                              ]),
+                           values_mapping={1: 'Warning'},
+                           )
+        node.derive(master_warning, takeoff_rolls)
+        self.assertEqual(len(node), 1)
+        self.assertEqual(node[0].index, 11)
+        self.assertEqual(node[0].value, 3)
+
+    def test_derive_single_sample(self):
+        node = self.node_class()
+        takeoff_rolls = buildsection('Takeoff Roll Or Rejected Takeoff', 0, 20)
+        master_warning = M(array=np.ma.array([0,1]*10),
+                           values_mapping={1: 'Warning'},
+                           )
+        node.derive(master_warning, takeoff_rolls)
+        self.assertEqual(len(node), 0)
 
 
 class TestMasterCautionDuringTakeoffDuration(unittest.TestCase, NodeTest):


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/35376158/41154747-149943a6-6b13-11e8-8f10-7e05ddb01b14.png)
The Master Warn Parameter is going off once every two seconds for a single sample. This is causing production to get hammered with millions of KPVs and Events.
![image](https://user-images.githubusercontent.com/35376158/41155028-2a4e81b0-6b14-11e8-92d2-967ed3a54f7d.png)

This commit allows KPVs to ignore single sample instances of the warning going off.