### PR TITLE
AE-2006 fallback_dt timezone issue fix

### DIFF
--- a/analysis_engine/split_hdf_to_segments.py
+++ b/analysis_engine/split_hdf_to_segments.py
@@ -874,8 +874,15 @@ def _calculate_start_datetime(hdf, fallback_dt, validation_dt):
     if fallback_dt is not None:
         if (fallback_dt.tzinfo is None or
                 fallback_dt.tzinfo.utcoffset(fallback_dt) is None):
-            # Assume fallback_dt is UTC.
+            # Assume fallback_dt is UTC
             fallback_dt = fallback_dt.replace(tzinfo=pytz.utc)
+        
+        # Even if fallback_dt is UTC, there's a chance that the timezone was
+        # wrong, so if we're still in the future, let's see if it's less than
+        # 12 hours, and if it is, try to fix it
+        if fallback_dt >= now and (fallback_dt - now).seconds/3600 < 12:
+            fallback_dt -= fallback_dt - now
+        
         assert fallback_dt <= now, (
             "Fallback time '%s' in the future is not allowed. Current time "
             "is '%s'." % (fallback_dt, now))


### PR DESCRIPTION
Investigation revealed that the issue was linked to time difference caused (most likely) by wrong clock settings on the DTU or the QAR. The issue ceased to occur on the 28th of October as this is when the DST ended. All flights that caused the problem were short (<1 hour), and even though the hdf.duration check worked ok, it moved fallback_dt back less than 1 hour, which, because of the timezone attribute still being UTC, but the actual time being wrong, caused fallback_dt to be few minutes (in some cases seconds) in the future. I have implemented a check - even if the timezone is UTC, if fallback_dt is in the future, the algorithm will now check if it’s less than 12 hours, and if it is, it’ll move fallback_dt back to ‘now’, so that the time will still be wrong, but at least the file will process instead of failing.

