### PR TITLE
AE-2097: Speedbrake Deployed/Selected fix for B787s

### DIFF
--- a/analysis_engine/multistate_parameters.py
+++ b/analysis_engine/multistate_parameters.py
@@ -2690,7 +2690,9 @@ class SpeedbrakeDeployed(MultistateDerivedParameterNode):
     }
 
     @classmethod
-    def can_operate(cls, available):
+    def can_operate(cls, available, family=A('Family')):
+        if family and family.value == 'B787':
+            return 'Speedbrake Handle' in available
 
         return 'Spoiler Deployed' in available or \
                all_of(('Spoiler (L) Deployed', 'Spoiler (R) Deployed'), available) or \

--- a/analysis_engine/multistate_parameters.py
+++ b/analysis_engine/multistate_parameters.py
@@ -2778,7 +2778,7 @@ class SpeedbrakeDeployed(MultistateDerivedParameterNode):
                 array[s] = True
             return array
 
-        if family.value == 'B787':
+        if family and family.value == 'B787':
             speedbrake = np.ma.zeros(len(handle.array), dtype=np.short)
             stepped_array = step_values(handle.array, [0, 20], hz=handle.hz)
             speedbrake[stepped_array == 20] = 1


### PR DESCRIPTION
This is a quick fix for B787s, it will most likely have to be improved at a later date. Previously, 'Speedbrake Selected' was being derived using 'Speedbrake Deployed'. The problem with this was that it was using Spoiler angles, this caused problems due to Spoiler offsets on some aircraft.  Both parameters now rely solely on 'Speedbrake Handle'.