### PR TITLE
AE-2126: Indexing DH Selected array instead of using at function

### DIFF
--- a/analysis_engine/key_point_values.py
+++ b/analysis_engine/key_point_values.py
@@ -19227,4 +19227,4 @@ class DHSelectedAt1500FtLVO(KeyPointValueNode):
             alt_aal_array = mask_outside_slices(alt_aal.array, [descent.slice])
             approach_index = np.ma.argmax(alt_aal_array <= 1500)
 
-            self.create_kpv(approach_index, dh_selected.at(approach_index))
+            self.create_kpv(approach_index, dh_selected.array[approach_index])

--- a/analysis_engine/key_point_values.py
+++ b/analysis_engine/key_point_values.py
@@ -19227,4 +19227,5 @@ class DHSelectedAt1500FtLVO(KeyPointValueNode):
             alt_aal_array = mask_outside_slices(alt_aal.array, [descent.slice])
             approach_index = np.ma.argmax(alt_aal_array <= 1500)
 
-            self.create_kpv(approach_index, dh_selected.array[approach_index])
+            if approach_index:
+                self.create_kpv(approach_index, dh_selected.array[approach_index])


### PR DESCRIPTION
Can confirm that it now returns the correct value as reported in the bottom comment of the ticket.

Also made a small change to not create the KPV if np.ma.argmax matches nothing.