### PR TITLE
Fine tuning the holding algorithm to reduce the sensitivity a little …

### DIFF
--- a/analysis_engine/flight_phase.py
+++ b/analysis_engine/flight_phase.py
@@ -211,7 +211,7 @@ class Holding(FlightPhaseNode):
         # We know turn rate will be positive because Heading Increasing only
         # increases.
         turn_bands = np.ma.clump_unmasked(
-            np.ma.masked_less(turn_rate[slices_int(to_scan)], 0.5))
+            np.ma.masked_less(turn_rate[slices_int(to_scan)], 0.6))
         hold_bands=[]
         for turn_band in shift_slices(turn_bands, to_scan.start):
             # Reject short periods and check that the average groundspeed was

--- a/tests/flight_phase_test.py
+++ b/tests/flight_phase_test.py
@@ -1579,10 +1579,10 @@ class TestHolding(unittest.TestCase):
         lon=P('Longitude Smoothed', np.ma.ones(11880) * 24.0)
         hold=Holding()
         hold.derive(alt, hdg, alt_max, tdwns, lat, lon)
-        self.assertEqual(hold[0].slice, slice(500, 1360))
-        self.assertEqual(hold[1].slice, slice(3400, 4260))
-        self.assertEqual(hold[2].slice, slice(6350, 7620))
-        self.assertEqual(hold[3].slice, slice(9790, 11210))
+        self.assertEqual(hold[0].slice, slice(510, 1350))
+        self.assertEqual(hold[1].slice, slice(3410, 4250))
+        self.assertEqual(hold[2].slice, slice(6370, 7600))
+        self.assertEqual(hold[3].slice, slice(9810, 11190))
 
     def test_hold_rejected_if_travelling(self):
         rot=np.ma.concatenate((


### PR DESCRIPTION
…and, consequentially, make the start and end closer hence the final groundspeed test passes for single orbit low rate turns. 


