### PR TITLE
AE-2555 Fix Gear Down In Transit and Gear Up In Transit

### DIFF
--- a/analysis_engine/multistate_parameters.py
+++ b/analysis_engine/multistate_parameters.py
@@ -43,6 +43,7 @@ from analysis_engine.library import (
     slice_duration,
     slices_and,
     slices_and_not,
+    slices_extend,
     slices_from_to,
     slices_overlap,
     slices_remove_small_gaps,
@@ -1606,7 +1607,7 @@ class GearDownInTransit(MultistateDerivedParameterNode):
                model=A('Model'), series=A('Series'), family=A('Family')):
 
         gear_sels = gear_ups = gear_downs = runs = []
-        self.array = np_ma_zeros_like(first_valid_parameter(gear_down, gear_up, gear_down_sel, gear_position).array)
+        self.array = np_ma_zeros_like(first_valid_parameter(gear_down, gear_up, gear_down_sel, gear_position).array, dtype=int)
 
         # work out fallback
         extend_duration = 0
@@ -1647,12 +1648,29 @@ class GearDownInTransit(MultistateDerivedParameterNode):
                     transit for transit in transits
                     if not slices_overlap(transit, gear_moving_up)
                 ]
+
+            if gear_red:
+                # Dataframes show spurious Gear Red Warnings.
+                # Only consider transits within a reasonable range of Gear Down.
+                gear_moving_downs = [
+                    slice(
+                        max(gear_down_edge - duration, 0),
+                        min(gear_down_edge + duration, len(self.array))
+                    )
+                    for gear_down_edge in gear_downs
+                ]
+                transits = [
+                            transit for gear_moving_down in gear_moving_downs
+                            for transit in transits
+                            if slices_overlap(transit, gear_moving_down)
+                        ]
+
             gear_down_slices = runs_of_ones(nearest_neighbour_mask_repair(gear_down.array) == 'Down')
             runs = slices_and_not(transits, gear_down_slices)
 
-            if family and family.value == 'B737 Classic' and fallback:
+            if family and family.value == 'B737 Classic' and extend_duration:
                 for idx, run in enumerate(runs):
-                    if slice_duration(run, self.frequency) > fallback:
+                    if slice_duration(run, self.frequency) > extend_duration:
                         stop = run.stop
                         runs[idx] = slice(int(math.ceil(stop-fallback)), stop)
 
@@ -1681,11 +1699,32 @@ class GearDownInTransit(MultistateDerivedParameterNode):
                     transit for transit in transits
                     if not slices_overlap(transit, gear_moving_up)
                 ]
-            runs = transits
 
-            if family and family.value == 'B737 Classic' and fallback:
+                if gear_red:
+                    # Dataframes show spurious Gear Red Warnings.
+                    # Only consider transits within a reasonable range of Gear Down.
+                    gear_downs = find_edges_on_state_change(
+                        'Down',
+                        nearest_neighbour_mask_repair(gear_up.array),
+                        phase=slices_extend(airborne.get_slices(), 1))  # Extend Airborne slices by 1 sample for low freq Gear Down
+                    gear_moving_downs = [
+                        slice(
+                            max(gear_down_edge - duration, 0),
+                            min(gear_down_edge + duration, len(self.array))
+                        )
+                        for gear_down_edge in gear_downs
+                    ]
+                    transits = [
+                                transit for gear_moving_down in gear_moving_downs
+                                for transit in transits
+                                if slices_overlap(transit, gear_moving_down)
+                            ]
+
+                runs = transits
+
+            if family and family.value == 'B737 Classic' and extend_duration:
                 for idx, run in enumerate(runs):
-                    if slice_duration(run, self.frequency) > fallback:
+                    if slice_duration(run, self.frequency) > extend_duration:
                         stop = run.stop
                         runs[idx] = slice(int(math.ceil(stop-fallback)), stop)
 
@@ -1767,7 +1806,7 @@ class GearUpInTransit(MultistateDerivedParameterNode):
                model=A('Model'), series=A('Series'), family=A('Family')):
 
         gear_sels = gear_ups = gear_downs = runs = []
-        self.array = np_ma_zeros_like(first_valid_parameter(gear_down, gear_up, gear_up_sel, gear_position).array)
+        self.array = np_ma_zeros_like(first_valid_parameter(gear_down, gear_up, gear_up_sel, gear_position).array, dtype=int)
 
         # work out fallback
         retract_duration = 0
@@ -1799,21 +1838,38 @@ class GearUpInTransit(MultistateDerivedParameterNode):
             gear_downs = find_edges_on_state_change('Down', nearest_neighbour_mask_repair(gear_up.array), phase=airborne)
             # Find transits within a reasonable range
             duration = fallback or 20 * self.frequency
-            for gear_down in gear_downs:
+            for gear_down_edge in gear_downs:
                 gear_moving_down = slice(
-                    max(gear_down - duration, 0),
-                    min(gear_down + duration, len(self.array))
+                    max(gear_down_edge - duration, 0),
+                    min(gear_down_edge + duration, len(self.array))
                 )
                 transits = [
                     transit for transit in transits
                     if not slices_overlap(transit, gear_moving_down)
                 ]
+
+            if gear_red:
+                # Dataframes show spurious Gear Red Warnings.
+                # Only consider transits within a reasonable range of Gear Up.
+                gear_moving_ups = [
+                    slice(
+                        max(gear_up_edge - duration, 0),
+                        min(gear_up_edge + duration, len(self.array))
+                    )
+                    for gear_up_edge in gear_ups
+                ]
+                transits = [
+                            transit for gear_moving_up in gear_moving_ups
+                            for transit in transits
+                            if slices_overlap(transit, gear_moving_up)
+                        ]
+
             gear_up_slices = runs_of_ones(nearest_neighbour_mask_repair(gear_up.array) == 'Up')
             runs = slices_and_not(transits, gear_up_slices)
 
-            if family and family.value == 'B737 Classic' and fallback:
+            if family and family.value == 'B737 Classic' and retract_duration:
                 for idx, run in enumerate(runs):
-                    if slice_duration(run, self.frequency) > fallback:
+                    if slice_duration(run, self.frequency) > retract_duration:
                         stop = run.stop
                         runs[idx] = slice(int(math.ceil(stop-fallback)), stop)
 
@@ -1824,7 +1880,7 @@ class GearUpInTransit(MultistateDerivedParameterNode):
                 stop = min([x for x in transits if x > start] or (None,))
                 if stop is not None:
                     _slice = slice(int(math.ceil(start)), stop+1)
-                    if family and family.value == 'B737 Classic' and fallback and slice_duration(_slice, self.frequency) > fallback:
+                    if family and family.value == 'B737 Classic' and retract_duration and slice_duration(_slice, self.frequency) > retract_duration:
                         _slice = slice(int(math.ceil(start)), start+fallback+1)
                     runs.append(_slice)
 
@@ -1845,11 +1901,33 @@ class GearUpInTransit(MultistateDerivedParameterNode):
                     transit for transit in transits
                     if not slices_overlap(transit, gear_moving_down)
                 ]
+
+            if gear_red:
+                # Dataframes show spurious Gear Red Warnings.
+                # Only consider transits within a reasonable range of Gear Up.
+                gear_ups = find_edges_on_state_change(
+                    'Up',
+                    nearest_neighbour_mask_repair(gear_down.array),
+                    phase=slices_extend(airborne.get_slices(), 1)  # Extend Airborne slices by 1 sample for low freq Gear Down
+                )
+                gear_moving_ups = [
+                    slice(
+                        max(gear_up_edge - duration, 0),
+                        min(gear_up_edge + duration, len(self.array))
+                    )
+                    for gear_up_edge in gear_ups
+                ]
+                transits = [
+                            transit for gear_moving_up in gear_moving_ups
+                            for transit in transits
+                            if slices_overlap(transit, gear_moving_up)
+                        ]
+
             runs = transits
 
-            if family and family.value == 'B737 Classic' and fallback:
+            if family and family.value == 'B737 Classic' and retract_duration:
                 for idx, run in enumerate(runs):
-                    if slice_duration(run, self.frequency) > fallback:
+                    if slice_duration(run, self.frequency) > retract_duration:
                         stop = run.stop
                         runs[idx] = slice(math.ceil(stop-fallback), stop)
 

--- a/tests/multistate_parameters_test.py
+++ b/tests/multistate_parameters_test.py
@@ -3949,12 +3949,14 @@ class TestGearUpInTransit(unittest.TestCase):
         # show a change. Can only be picked up if we record one of the following
         # parameters: Gear Position, Gear In Transit, Gear Red or
         # Gear Up Selected. See GearDownInTransit test for more info.
+        # Gear Red Warnings unfortunately triggers spuriously on some dataframes.
+        # So we cannot detect this edge case with Red Warnings.
         self.expected_short = M('Gear Up In Transit', array=np.ma.array([0]*5 + [1]*3 + [0]*7 + [1]*10 + [0]*35),
                                 values_mapping=self.values_mapping)
         self.family = A('Aircraft Family', value='Generic Family')
         self.series = A('Aircraft Series', value='Generic Series')
         self.model = A('Aircraft Model', value='Generic Model')
-        self.airborne=buildsection('Airborne', 0, 59)
+        self.airborne=buildsection('Airborne', 1, 59)
 
     def test_can_operate(self):
         combinations = self.node_class.get_operational_combinations()
@@ -4148,26 +4150,26 @@ class TestGearUpInTransit(unittest.TestCase):
         # Gear Down changed to Up + transition time
         gear_down = M('Gear Down', array=np.ma.array([1]*5 + [0]*50 + [1]*5),
                    values_mapping={0: 'Up', 1: 'Down'})
-        red_warn = M('Gear (*) Red Warning', array=np.ma.array([0]*5 + [1]*3 + [0]*7 + [1]*10 + [0]*20 + [1]*10 + [0]*5),
+        red_warn = M('Gear (*) Red Warning', array=np.ma.array([0]*5 + [1]*10 + [0]*10 + [1]*3 + [0]*17 + [1]*10 + [0]*5),
                       values_mapping={0: '-', 1: 'Warning'})
         node = self.node_class()
         node.derive(gear_down, None, None, None, red_warn, None, self.airborne, self.model, self.series, self.family)
-
-        np.testing.assert_array_equal(node.array, self.expected_short.array)
+        # Gear Red Warning triggers spuriously. Cannot detect short periods not linked with Gear Down.
+        np.testing.assert_array_equal(node.array, self.expected.array)
         self.assertEqual(node.values_mapping, self.values_mapping)
 
     @patch('analysis_engine.multistate_parameters.at')
     def test_derive__gear_up_red_warn(self, at):
-        at.get_gear_transition_times.return_value = (10, 10)  # patch transition time to be 10 seconds
+        at.get_gear_transition_times.return_value = (5, 5)  # patch transition time to be 5 seconds
         # Gear Up changed to Up - transition time
-        gear_up = M('Gear Up', array=np.ma.array([0]*25 + [1]*20 + [0]*15),
+        gear_up = M('Gear Up', array=np.ma.array([0]*15 + [1]*30 + [0]*15),
                    values_mapping={0: 'Down', 1: 'Up'})
-        red_warn = M('Gear (*) Red Warning', array=np.ma.array([0]*5 + [1]*3 + [0]*7 + [1]*10 + [0]*20 + [1]*10 + [0]*5),
+        red_warn = M('Gear (*) Red Warning', array=np.ma.array([0]*5 + [1]*10 + [0]*10 + [1]*3 + [0]*17 + [1]*10 + [0]*5),
                       values_mapping={0: '-', 1: 'Warning'})
         node = self.node_class()
         node.derive(None, gear_up, None, None, red_warn, None, self.airborne, self.model, self.series, self.family)
-
-        np.testing.assert_array_equal(node.array, self.expected_short.array)
+        # Gear Red Warning triggers spuriously. Cannot detect short periods not linked with Gear Up.
+        np.testing.assert_array_equal(node.array, self.expected.array)
         self.assertEqual(node.values_mapping, self.values_mapping)
 
     @patch('analysis_engine.multistate_parameters.at')
@@ -4176,12 +4178,12 @@ class TestGearUpInTransit(unittest.TestCase):
         # Gear Down changed to Up + transition time
         gear_down = M('Gear Down', array=np.ma.array([1]*5 + [0]*50 + [1]*5),
                    values_mapping={0: 'Up', 1: 'Down'})
-        red_warn = M('Gear (*) Red Warning', array=np.ma.array([0]*5 + [1]*3 + [0]*7 + [1]*10 + [0]*20 + [1]*10 + [0]*5),
+        red_warn = M('Gear (*) Red Warning', array=np.ma.array([0]*5 + [1]*10 + [0]*10 + [1]*3 + [0]*17 + [1]*10 + [0]*5),
                       values_mapping={0: '-', 1: 'Warning'})
         node = self.node_class()
         node.derive(gear_down, None, None, None, red_warn, None, self.airborne, self.model, self.series, A('Family', value='B737 Classic'))
-
-        np.testing.assert_array_equal(node.array, self.expected_short.array)
+        # Gear Red Warning triggers spuriously. Cannot detect short periods not linked with Gear Down.
+        np.testing.assert_array_equal(node.array, self.expected.array)
         self.assertEqual(node.values_mapping, self.values_mapping)
 
 
@@ -4211,12 +4213,14 @@ class TestGearDownInTransit(unittest.TestCase):
         # that moment. We ought to detect that period too when recording the
         # necessary parameters: Gear Position, Gear In Transit, Gear Red or
         # Gear Down Selected
+        # Gear Red Warnings unfortunately triggers spuriously on some dataframes.
+        # So we cannot detect this edge case with Red Warnings.
         self.expected_short = M('Gear Down In Transit', array=np.ma.array([0]*35 + [1]*3 + [0]*7 + [1]*10 + [0]*5),
                                 values_mapping=self.values_mapping)
         self.family = A('Aircraft Family', value='Generic Family')
         self.series = A('Aircraft Series', value='Generic Series')
         self.model = A('Aircraft Model', value='Generic Model')
-        self.airborne=buildsection('Airborne', 0, 59)
+        self.airborne=buildsection('Airborne', 1, 59)
 
     def test_can_operate(self):
         combinations = self.node_class.get_operational_combinations()
@@ -4385,23 +4389,27 @@ class TestGearDownInTransit(unittest.TestCase):
                       values_mapping={0: '-', 1: 'Warning'})
         node = self.node_class()
         node.derive(gear_down, None, None, None, red_warn, None, self.airborne, self.model, self.series, self.family)
-
-        np.testing.assert_array_equal(node.array, self.expected_short.array)
+        # Gear Red Warning triggers spuriously. Cannot detect short periods not linked with Gear Down.
+        expected_short = M('Gear Down In Transit', array=np.ma.array([0]*45 + [1]*10 + [0]*5),
+                                        values_mapping=self.values_mapping)
+        np.testing.assert_array_equal(node.array, expected_short.array)
         self.assertEqual(node.values_mapping, self.values_mapping)
 
     @patch('analysis_engine.multistate_parameters.at')
     def test_derive__gear_up_red_warning(self, at):
-        at.get_gear_transition_times.return_value = (10, 10)
+        at.get_gear_transition_times.return_value = (5, 5)
         # Gear Up changed to Up + Red Warning
-        ac_series = A('Generic') # patch transition time to be 10 seconds
+        ac_series = A('Generic') # patch transition time to be 5 seconds
         gear_up = M('Gear Up', array=np.ma.array([0]*15 + [1]*30 + [0]*15),
                    values_mapping={0: 'Down', 1: 'Up'})
         red_warn = M('Gear (*) Red Warning', array=np.ma.array([0]*5 + [1]*10 + [0]*20 + [1]*3 + [0]*7 + [1]*10 + [0]*5),
                       values_mapping={0: '-', 1: 'Warning'})
         node = self.node_class()
         node.derive(None, gear_up, None, None, red_warn, None, self.airborne, self.model, self.series, self.family)
-
-        np.testing.assert_array_equal(node.array, self.expected_short.array)
+        # Gear Red Warning triggers spuriously. Cannot detect short periods not linked with Gear Down.
+        expected_short = M('Gear Down In Transit', array=np.ma.array([0]*45 + [1]*10 + [0]*5),
+                                        values_mapping=self.values_mapping)
+        np.testing.assert_array_equal(node.array, expected_short.array)
         self.assertEqual(node.values_mapping, self.values_mapping)
 
     @patch('analysis_engine.multistate_parameters.at')


### PR DESCRIPTION
It was found out that many dataframes trigger spurious Gear (*) Red Warnings.
The end goal is to fix those frames. In the meantime, it's been decided to
filter out the Red Warnings and only use those close to Gear Up or
Gear Down to determine the transition periods.

Also fixed the dtype for those 2 Multistate Parameters to int.
Fixed timing errors for B737 Classic where the number of frames was used
instead of the timing.