### PR TITLE
bugfix/DJ/AE-2709_EngBleedValvesAtLiftoff_slow_to_compute

### DIFF
--- a/analysis_engine/key_point_values.py
+++ b/analysis_engine/key_point_values.py
@@ -9724,8 +9724,8 @@ class EngBleedValvesAtLiftoff(KeyPointValueNode):
         ), available)
 
     def derive(self,
-               liftoffs=KTI('Liftoff'),
-               bleed=M('Eng Bleed Open')):
+               bleed=M('Eng Bleed Open'),
+               liftoffs=KTI('Liftoff')):
 
         self.create_kpvs_at_ktis(bleed.array == 'Open', liftoffs)
 

--- a/tests/key_point_value_test.py
+++ b/tests/key_point_value_test.py
@@ -10991,7 +10991,7 @@ class TestEngBleedValvesAtLiftoff(unittest.TestCase, NodeTest):
         values_mapping = {0: 'Closed', 1: 'Open'}
         bleed = M('Eng Bleed Open', array=np.ma.masked_array([0, 1, 1, 1, 0]), values_mapping=values_mapping)
         node = EngBleedValvesAtLiftoff()
-        node.derive(liftoff, bleed)
+        node.derive(bleed, liftoff)
         self.assertEqual(node, KPV('Eng Bleed Valves At Liftoff', items=[
             KeyPointValue(name='Eng Bleed Valves At Liftoff', index=3, value=1),
         ]))


### PR DESCRIPTION
Reversing parameters avoids upsampling bleed valve data hence avoids unjustified slow operation.