### PR TITLE
AE-2715 Revise RollRateForTouchdown and RollRateMaxAboveLimitAtTouchdown

### DIFF
--- a/analysis_engine/derived_parameters.py
+++ b/analysis_engine/derived_parameters.py
@@ -6353,32 +6353,26 @@ class RollRateAtTouchdownLimit(DerivedParameterNode):
         '''
         Embraer 175 - AMM 2134
         200-802-A/600
-        Rev 52 - Nov 24/17
+        Rev 74 - Sep 20/19
 
         E175 Aircraft Maintenance Manual, Roll Rate Calculation and Threshold,
-        Figure 606 - Sheet 2
+        Figure 608
 
-        The following method returns an approximation of the roll limit curve.
-
-        For weights between 20000kg and 21999kg approximate (values returned are
-        slightly below the limit) roll rate limit is:    def test_can_operate(self):
-        opts = RollRateAtTouchdownLimit.get_operational_combinations()
-        self.assertTrue(('Gross Weight Smoothed', 'ERJ-170/175') in opts)
-        f(x) = -0.001x + 34
-
-        For weights between 22000kg and 38000kg roll rate limit is a function:
-        f(x) = -0.000375x + 20.75
-
-        For weights between 38001kg and 40000kg we assume a limit of 6 degrees per second,
-        which again, is slightly below the limit.
+        The maximum roll rate is a linear function of the gross weight passing by
+        two given points: (weight low, roll rate high) and (weight high, roll rate low).
         '''
 
+        weight_low = 21_800
+        weight_high = 38_790
+        roll_rate_high = 12.4
+        roll_rate_low = 6.3
+
+        slope = (roll_rate_low - roll_rate_high) / (weight_high - weight_low)
+        intercept = roll_rate_high - slope * weight_low
+
         self.array = np_ma_masked_zeros_like(gw.array)
-        range1 = (20000 <= gw.array) & (gw.array < 22000)
-        self.array[range1] = gw.array[range1] * -0.001 + 34
-        range2 = (22000 <= gw.array) & (gw.array <= 38000)
-        self.array[range2] = gw.array[range2] * -0.000375 + 20.75
-        self.array[(38000 < gw.array) & (gw.array <= 40000)] = 6
+        range_ = (weight_low <= gw.array) & (gw.array <= weight_high)
+        self.array[range_] = slope * gw.array[range_] + intercept
 
 
 class AccelerationNormalLowLimitForLandingWeight(DerivedParameterNode):

--- a/analysis_engine/key_point_values.py
+++ b/analysis_engine/key_point_values.py
@@ -16700,24 +16700,43 @@ class RollRateMaxAboveLimitAtTouchdown(KeyPointValueNode):
     def derive(self,
                roll_rate=P('Roll Rate For Touchdown'),
                limit=P('Roll Rate At Touchdown Limit'),
-               touchdowns=KTI('Touchdown'),
-               touch_and_go=KTI('Touch And Go'),
-               bounces=S('Bounced Landing'),):
+               gw=P('Gross Weight Smoothed'),
+               acc_norm_tdwns=KPV('Acceleration Normal At Touchdown'),):
 
-        tdwns = touchdowns
-        if touch_and_go:
-            tdwns += touch_and_go
-
-        indices = [touchdown.index for touchdown in tdwns] + \
-                  [bounce.slice.stop for bounce in bounces]
-
-        for i in indices:
+        for acc_norm_tdwn in acc_norm_tdwns:
+            i = acc_norm_tdwn.index
+            if acc_norm_tdwn.value < self._min_vert_acceleration(gw.array[int(i)]):
+                # Check for minimum vertical acceleration
+                continue
             window_start = i - (2*self.hz)
             window_end = i + (2*self.hz) + 1 # +1 so that the number of indices is equal on both sides of peak acceleration
             window_slice = slices_int(window_start, window_end)
             rr_over_limit = abs(roll_rate.array[window_slice]) - \
                             limit.array[window_slice]
             self.create_kpv(np.argmax(rr_over_limit)+window_start, max(rr_over_limit))
+
+    def _min_vert_acceleration(self, gross_weight):
+        '''
+        Embraer 175 - AMM 2134
+        200-802-A/600
+        Rev 74 - Sep 20/19
+
+        E175 Aircraft Maintenance Manual, Minimum Vertical Acceleration to consider roll
+        rate cases.
+        Figure 614
+
+        Minimum vertical acceleration is a linear function of gross weight passing by
+        two given points: (weight low, roll rate high) and (weight high, roll rate low).
+        '''
+        weight_low = 21_800
+        weight_high = 38_790
+        vert_acc_high = 1.83
+        vert_acc_low = 1.20
+
+        slope = (vert_acc_low - vert_acc_high) / (weight_high - weight_low)
+        intercept = vert_acc_high - slope * weight_low
+
+        return gross_weight * slope + intercept
 
 
 ##############################################################################

--- a/tests/derived_parameters_test.py
+++ b/tests/derived_parameters_test.py
@@ -6399,14 +6399,14 @@ class TestRollRateForTouchdown(unittest.TestCase):
 class TestRollRateAtTouchdownLimit(unittest.TestCase):
     def test_derive(self):
         gw = P('Gross Weight Smoothed', np.ma.masked_array(
-            [10000, 20000, 20000, 22000, 34000, 38000, 40000, 50000],
+            [10000, 20000, 20000, 21800, 34000, 38790, 40000, 50000],
             mask=[False, True, False, False, False, False, False, False]))
         expected_result = np.ma.masked_array(
-            [0, 0, 14, 12.5, 8, 6.5, 6, 0],
-            mask=[True, True, False, False, False, False, False, True])
+            [0, 0, 0, 12.4, 8.02, 6.3, 0, 0],
+            mask=[True, True, True, False, False, False, True, True])
         node = RollRateAtTouchdownLimit()
         node.derive(gw)
-        assert_array_almost_equal(node.array, expected_result)
+        assert_array_almost_equal(node.array, expected_result, decimal=3)
 
 
 class TestRudderPedalCapt(unittest.TestCase):

--- a/tests/key_point_value_test.py
+++ b/tests/key_point_value_test.py
@@ -18875,7 +18875,10 @@ class TestRollAboveFL300Max(unittest.TestCase):
 
 class TestRollRateMaxAboveLimitAtTouchdown(unittest.TestCase):
     def test_high_roll_at_touchdown(self):
-        touchdowns = KTI('Touchdown', items=[KeyTimeInstance(13, 'Touchdown')])
+        acc_norm_tdwns = KPV(
+            'Acceleration Normal At Touchdown',
+            items=[KeyPointValue(13, 1.7, 'Acceleration Normal At Touchdown')])
+        gw = P('Gross Weight Smoothed', array=np.ma.ones(25) * 28_000)
 
         limit=P('Roll Rate At Touchdown Limit',
                 np.ma.array([0, 0, 0, 0, 0,
@@ -18883,78 +18886,6 @@ class TestRollRateMaxAboveLimitAtTouchdown(unittest.TestCase):
                              0, 0, 0, 0, 0,
                              0, 0, 0, 0, 0,
                              0, 0, 0, 0, 0, ]))
-
-        roll_rate=P('Roll Rate For Touchdown',
-                    np.ma.array([0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0,
-                             2, 3, 4, 3, 2,
-                             0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0, ]))
-
-        node = RollRateMaxAboveLimitAtTouchdown()
-        node.derive(roll_rate, limit, touchdowns=touchdowns)
-
-        self.assertEqual(node[0].index, 12)
-        self.assertEqual(node[0].value, 4)
-
-
-    def test_high_roll_before_td_window(self):
-        touchdowns = KTI('Touchdown', items=[KeyTimeInstance(13, 'Touchdown')])
-
-        limit=P('Roll Rate At Touchdown Limit',
-                np.ma.array([0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0, ]))
-
-        roll_rate=P('Roll Rate For Touchdown',
-                    np.ma.array([0, 0, 0, 0, 0,
-                                 0, 1, 2, 3, 4,
-                                 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0, ]))
-
-        node = RollRateMaxAboveLimitAtTouchdown()
-        node.derive(roll_rate, limit, touchdowns=touchdowns)
-
-        self.assertEqual(node[0].index, 11)
-        self.assertEqual(node[0].value, 0)
-
-
-    def test_high_roll_beginning_of_window(self):
-        touchdowns = KTI('Touchdown', items=[KeyTimeInstance(12, 'Touchdown')])
-
-        limit=P('Roll Rate At Touchdown Limit',
-                np.ma.array([0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0, ]))
-
-        roll_rate=P('Roll Rate For Touchdown',
-                    np.ma.array([0, 0, 0, 0, 0,
-                                 0, 0, 2, 3, 4,
-                                 5, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0, ]))
-
-        node = RollRateMaxAboveLimitAtTouchdown()
-        node.derive(roll_rate, limit, touchdowns=touchdowns)
-
-        self.assertEqual(node[0].index, 10)
-        self.assertEqual(node[0].value, 5)
-
-
-    def test_high_roll_end_of_window(self):
-        touchdowns = KTI('Touchdown', items=[KeyTimeInstance(8, 'Touchdown')])
-
-        limit=P('Roll Rate At Touchdown Limit',
-                np.ma.array([0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0, ]))
 
         roll_rate=P('Roll Rate For Touchdown',
                     np.ma.array([0, 0, 0, 0, 0,
@@ -18964,21 +18895,104 @@ class TestRollRateMaxAboveLimitAtTouchdown(unittest.TestCase):
                                  0, 0, 0, 0, 0, ]))
 
         node = RollRateMaxAboveLimitAtTouchdown()
-        node.derive(roll_rate, limit, touchdowns=touchdowns)
+        node.derive(roll_rate, limit, gw, acc_norm_tdwns)
+
+        self.assertEqual(node[0].index, 12)
+        self.assertEqual(node[0].value, 4)
+
+
+    def test_high_roll_before_td_window(self):
+        acc_norm_tdwns = KPV(
+            'Acceleration Normal At Touchdown',
+            items=[KeyPointValue(13, 1.7, 'Acceleration Normal At Touchdown')])
+        gw = P('Gross Weight Smoothed', array=np.ma.ones(25) * 28_000)
+        limit=P('Roll Rate At Touchdown Limit',
+                np.ma.array([0, 0, 0, 0, 0,
+                             0, 0, 0, 0, 0,
+                             0, 0, 0, 0, 0,
+                             0, 0, 0, 0, 0,
+                             0, 0, 0, 0, 0, ]))
+
+        roll_rate=P('Roll Rate For Touchdown',
+                    np.ma.array([0, 0, 0, 0, 0,
+                                 0, 1, 2, 3, 4,
+                                 0, 0, 0, 0, 0,
+                                 0, 0, 0, 0, 0,
+                                 0, 0, 0, 0, 0, ]))
+
+        node = RollRateMaxAboveLimitAtTouchdown()
+        node.derive(roll_rate, limit, gw, acc_norm_tdwns)
+
+        self.assertEqual(node[0].index, 11)
+        self.assertEqual(node[0].value, 0)
+
+
+    def test_high_roll_beginning_of_window(self):
+        acc_norm_tdwns = KPV(
+            'Acceleration Normal At Touchdown',
+            items=[KeyPointValue(12, 1.7, 'Acceleration Normal At Touchdown')])
+        gw = P('Gross Weight Smoothed', array=np.ma.ones(25) * 28_000)
+
+        limit=P('Roll Rate At Touchdown Limit',
+                np.ma.array([0, 0, 0, 0, 0,
+                             0, 0, 0, 0, 0,
+                             0, 0, 0, 0, 0,
+                             0, 0, 0, 0, 0,
+                             0, 0, 0, 0, 0, ]))
+
+        roll_rate=P('Roll Rate For Touchdown',
+                    np.ma.array([0, 0, 0, 0, 0,
+                                 0, 0, 2, 3, 4,
+                                 5, 0, 0, 0, 0,
+                                 0, 0, 0, 0, 0,
+                                 0, 0, 0, 0, 0, ]))
+
+        node = RollRateMaxAboveLimitAtTouchdown()
+        node.derive(roll_rate, limit, gw, acc_norm_tdwns)
+
+        self.assertEqual(node[0].index, 10)
+        self.assertEqual(node[0].value, 5)
+
+
+    def test_high_roll_end_of_window(self):
+        acc_norm_tdwns = KPV(
+            'Acceleration Normal At Touchdown',
+            items=[KeyPointValue(8, 1.7, 'Acceleration Normal At Touchdown')])
+        gw = P('Gross Weight Smoothed', array=np.ma.ones(25) * 28_000)
+
+        limit=P('Roll Rate At Touchdown Limit',
+                np.ma.array([0, 0, 0, 0, 0,
+                             0, 0, 0, 0, 0,
+                             0, 0, 0, 0, 0,
+                             0, 0, 0, 0, 0,
+                             0, 0, 0, 0, 0, ]))
+
+        roll_rate=P('Roll Rate For Touchdown',
+                    np.ma.array([0, 0, 0, 0, 0,
+                                 0, 0, 0, 0, 0,
+                                 2, 3, 4, 3, 2,
+                                 0, 0, 0, 0, 0,
+                                 0, 0, 0, 0, 0, ]))
+
+        node = RollRateMaxAboveLimitAtTouchdown()
+        node.derive(roll_rate, limit, gw, acc_norm_tdwns)
 
         self.assertEqual(node[0].index, 10)
         self.assertEqual(node[0].value, 2)
 
 
     def test_high_roll_after_landing(self):
-        touchdowns = KTI('Touchdown', items=[KeyTimeInstance(13, 'Touchdown')])
+        acc_norm_tdwns = KPV(
+            'Acceleration Normal At Touchdown',
+            items=[KeyPointValue(13, 1.7, 'Acceleration Normal At Touchdown')])
+        gw = P('Gross Weight Smoothed', array=np.ma.ones(25) * 28_000)
 
         limit=P('Roll Rate At Touchdown Limit',
                 np.ma.array([0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0, ]))
+                             0, 0, 0, 0, 0,
+                             0, 0, 0, 0, 0,
+                             0, 0, 0, 0, 0,
+                             0, 0, 0, 0, 0, ]))
 
         roll_rate=P('Roll Rate For Touchdown',
                     np.ma.array([0, 0, 0, 0, 0,
@@ -18988,117 +19002,43 @@ class TestRollRateMaxAboveLimitAtTouchdown(unittest.TestCase):
                                  0, 2, 3, 4, 5, ]))
 
         node = RollRateMaxAboveLimitAtTouchdown()
-        node.derive(roll_rate, limit, touchdowns=touchdowns)
+        node.derive(roll_rate, limit, gw, acc_norm_tdwns)
 
         self.assertEqual(node[0].index, 11)
         self.assertEqual(node[0].value, 0)
 
 
     def test_normal_landing(self):
-        touchdowns = KTI('Touchdown', items=[KeyTimeInstance(13, 'Touchdown')])
+        acc_norm_tdwns = KPV(
+            'Acceleration Normal At Touchdown',
+            items=[KeyPointValue(13, 1.7, 'Acceleration Normal At Touchdown')])
+        gw = P('Gross Weight Smoothed', array=np.ma.ones(25) * 28_000)
 
         limit=P('Roll Rate At Touchdown Limit',
-                np.ma.array([0, 0, 0, 0, 0,
+                array=np.ma.ones(25) * 10)
+
+        roll_rate=P('Roll Rate For Touchdown',
+                    np.ma.array([0, 0, 0, 0, 0,
                                  0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0,
+                                 0, 0, 2, -3, -1,
                                  0, 0, 0, 0, 0,
                                  0, 0, 0, 0, 0, ]))
 
-        roll_rate=P('Roll Rate For Touchdown',
-                    np.ma.array([0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0, ]))
-
         node = RollRateMaxAboveLimitAtTouchdown()
-        node.derive(roll_rate, limit, touchdowns=touchdowns)
+        node.derive(roll_rate, limit, gw, acc_norm_tdwns)
 
-        self.assertEqual(node[0].index, 11)
-        self.assertEqual(node[0].value, 0)
+        self.assertEqual(node[0].index, 13)
+        self.assertEqual(node[0].value, -7)
 
-
-    def test_high_roll_bounce_after_normal_landing(self):
-        touchdowns = KTI('Touchdown', items=[KeyTimeInstance(13, 'Touchdown')])
-        bounces = buildsection('Bounced Landing', 13, 17)
-
-        limit=P('Roll Rate At Touchdown Limit',
-                np.ma.array([0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0, ]))
-
-        roll_rate=P('Roll Rate For Touchdown',
-                    np.ma.array([0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0,
-                             3, 3, 3, 0, 0,
-                             0, 0, 0, 0, 0, ]))
-
-        node = RollRateMaxAboveLimitAtTouchdown()
-        node.derive(roll_rate, limit, touchdowns=touchdowns, bounces=bounces)
-
-        self.assertEqual(node[0].index, 15)
-        self.assertEqual(node[0].value, 3)
-
-
-    def test_normal_bounce_after_high_roll_landing(self):
-        touchdowns = KTI('Touchdown', items=[KeyTimeInstance(13, 'Touchdown')])
-        bounces = buildsection('Bounced Landing', 13, 17)
-
-        limit=P('Roll Rate At Touchdown Limit',
-                np.ma.array([0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0, ]))
-
-        roll_rate=P('Roll Rate For Touchdown',
-                    np.ma.array([0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0,
-                             2, 3, 4, 0, 0,
-                             0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0, ]))
-
-        node = RollRateMaxAboveLimitAtTouchdown()
-        node.derive(roll_rate, limit, touchdowns=touchdowns, bounces=bounces)
-
-        self.assertEqual(node[0].index, 12)
-        self.assertEqual(node[0].value, 4)
-
-
-    def test_high_roll_bounce_after_high_roll_landing(self):
-        touchdowns = KTI('Touchdown', items=[KeyTimeInstance(13, 'Touchdown')])
-        bounces = buildsection('Bounced Landing', 13, 17)
-
-        limit=P('Roll Rate At Touchdown Limit',
-                np.ma.array([0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0, ]))
-
-        roll_rate=P('Roll Rate For Touchdown',
-                    np.ma.array([0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0,
-                             2, 3, 4, 0, 0,
-                             3, 3, 3, 0, 0,
-                             0, 0, 0, 0, 0, ]))
-
-        node = RollRateMaxAboveLimitAtTouchdown()
-        node.derive(roll_rate, limit, touchdowns=touchdowns, bounces=bounces)
-
-        self.assertEqual(node[0].index, 12)
-        self.assertEqual(node[0].value, 4)
-        self.assertEqual(node[1].index, 16)
-        self.assertEqual(node[1].value, 3)
-
-
-    def test_touch_and_go_landing_and_bounce(self):
-        touchdowns = KTI('Touchdown', items=[KeyTimeInstance(13, 'Touchdown')])
-        touch_and_go = KTI('Touch And Go', items=[KeyTimeInstance(3, 'Touch And Go')])
-        bounces = buildsection('Bounced Landing', 13, 17)
+    def test_touch_and_go_then_landing(self):
+        acc_norm_tdwns = KPV(
+            'Acceleration Normal At Touchdown',
+            items=[
+                KeyPointValue(3, 1.7, 'Acceleration Normal At Touchdown'),
+                KeyPointValue(13, 1.7, 'Acceleration Normal At Touchdown'),
+            ]
+        )
+        gw = P('Gross Weight Smoothed', array=np.ma.ones(25) * 28_000)
 
         limit=P('Roll Rate At Touchdown Limit',
                 np.ma.array([0, 0, 0, 0, 0,
@@ -19109,20 +19049,39 @@ class TestRollRateMaxAboveLimitAtTouchdown(unittest.TestCase):
 
         roll_rate=P('Roll Rate For Touchdown',
                     np.ma.array([0, 1, 3, 1, 0,
-                             0, 0, 0, 0, 0,
-                             2, 3, 4, 0, 0,
-                             3, 3, 3, 0, 0,
-                             0, 0, 0, 0, 0, ]))
+                                 0, 0, 0, 0, 0,
+                                 2, 3, 4, 0, 0,
+                                 3, 3, 3, 0, 0,
+                                 0, 0, 0, 0, 0, ]))
 
         node = RollRateMaxAboveLimitAtTouchdown()
-        node.derive(roll_rate, limit, touchdowns=touchdowns, touch_and_go=touch_and_go, bounces=bounces)
+        node.derive(roll_rate, limit, gw, acc_norm_tdwns)
 
-        self.assertEqual(node[0].index, 12)
-        self.assertEqual(node[0].value, 4)
-        self.assertEqual(node[1].index, 2)
-        self.assertEqual(node[1].value, 3)
-        self.assertEqual(node[2].index, 16)
-        self.assertEqual(node[2].value, 3)
+        self.assertEqual(node[0].index, 2)
+        self.assertEqual(node[0].value, 3)
+        self.assertEqual(node[1].index, 12)
+        self.assertEqual(node[1].value, 4)
+
+    def test_accel_vert_below_minimum(self):
+        acc_norm_tdwns = KPV(
+            'Acceleration Normal At Touchdown',
+            items=[KeyPointValue(13, 1.3, 'Acceleration Normal At Touchdown')])
+        gw = P('Gross Weight Smoothed', array=np.ma.ones(25) * 28_000)
+
+        limit=P('Roll Rate At Touchdown Limit',
+                array=np.ma.ones(25) * 10)
+
+        roll_rate=P('Roll Rate For Touchdown',
+                    np.ma.array([0, 0, 0, 0, 0,
+                                 0, 0, 0, 0, 0,
+                                 0, 3, 4, 5, 0,
+                                 0, 0, 0, 0, 0,
+                                 0, 0, 0, 0, 0, ]))
+
+        node = RollRateMaxAboveLimitAtTouchdown()
+        node.derive(roll_rate, limit, gw, acc_norm_tdwns)
+
+        self.assertEqual(len(node), 0)
 
 
 ##############################################################################


### PR DESCRIPTION
A new AMM revision changed the logic for maximum roll rate at touchdown for the
Embraer 175. It goes in 2 steps:
- Determine if the vertical acceleration is above a minimum threshold
  (threshold is a linear function of the gross weight)
- Measure the difference between Max roll rate and current roll rate.
  (Max roll rate is also a linear function of grossweight)