### PR TITLE
AE-2263 Restrict KPV to non-stationary phases.

### DIFF
--- a/analysis_engine/key_point_values.py
+++ b/analysis_engine/key_point_values.py
@@ -4287,10 +4287,12 @@ class GroundspeedWithThrustReversersDeployedAnyPowerMin(KeyPointValueNode):
 
     def derive(self,
                gnd_spd=P('Groundspeed'),
-               tr=M('Thrust Reversers'),):
+               tr=M('Thrust Reversers'),
+               stationaries=S('Stationary')):
 
         tr_deployed = runs_of_ones(tr.array == 'Deployed')
-        self.create_kpv_from_slices(gnd_spd.array, tr_deployed, min_value)
+        tr_deployed_moving = slices_and_not(tr_deployed, stationaries.get_slices())
+        self.create_kpv_from_slices(gnd_spd.array, tr_deployed_moving, min_value)
 
 
 ########################################

--- a/analysis_engine/multistate_parameters.py
+++ b/analysis_engine/multistate_parameters.py
@@ -3855,7 +3855,8 @@ class ThrustReversers(MultistateDerivedParameterNode):
         array = np.ma.where(deployed_stack.all(axis=0), 2, array)
 
         # update with any transit params
-        if any((e1_tst_all, e2_tst_all, e3_tst_all, e4_tst_all)):
+        if any((e1_tst_all, e2_tst_all, e3_tst_all, e4_tst_all,
+                e1_status, e2_status, e3_status, e4_status)):
             transit_stack = vstack_params_where_state(
                 (e1_tst_all, 'In Transit'), (e2_tst_all, 'In Transit'),
                 (e3_tst_all, 'In Transit'), (e4_tst_all, 'In Transit'),

--- a/tests/key_point_value_test.py
+++ b/tests/key_point_value_test.py
@@ -5722,13 +5722,34 @@ class TestAirspeedAtThrustReversersSelection(unittest.TestCase, NodeTest):
 
 class TestGroundspeedWithThrustReversersDeployedAnyPowerMin(unittest.TestCase, NodeTest):
 
+    def setUp(self):
+        self.node_class = GroundspeedWithThrustReversersDeployedAnyPowerMin
+        self.operational_combinations = [
+            ('Groundspeed', 'Thrust Reversers', 'Stationary')
+        ]
+
     def test_derive_basic(self):
-        gnd_spd = P('Groundspeed True', array=np.ma.arange(100, 0, -10))
+        gnd_spd = P('Groundspeed', array=np.ma.arange(100, 0, -10))
         tr = M('Thrust Reversers', array=np.ma.array([0] * 3 + [1] + [2] * 4 + [1,0]),
                values_mapping={0: 'Stowed', 1: 'In Transit', 2: 'Deployed'})
+        stationaries = buildsection('Stationary', 0, 3)
+        node = self.node_class()
+        node.derive(gnd_spd, tr, stationaries)
+        self.assertEqual(len(node), 1)
+        self.assertEqual(node[0], KeyPointValue(
+            index=7, value=30.0, name='Groundspeed With Thrust Reversers Deployed Any Power Min'))
 
-        node = GroundspeedWithThrustReversersDeployedAnyPowerMin()
-        node.derive(gnd_spd, tr)
+    def test_spurious_thrust_reversers_while_stationary(self):
+        gnd_spd = P('Groundspeed', array=np.ma.concatenate((np.ma.arange(100, 0, -10), np.ma.zeros(10))))
+        tr_data = np.ma.zeros(20)
+        tr_data[3:8] = [1, 2, 2, 2, 2]
+        tr_data[14:16] = 2
+        tr = M('Thrust Reversers', array=tr_data,
+               values_mapping={0: 'Stowed', 1: 'In Transit', 2: 'Deployed'})
+
+        stationaries = buildsection('Stationary', 10, 20)
+        node = self.node_class()
+        node.derive(gnd_spd, tr, stationaries)
         self.assertEqual(len(node), 1)
         self.assertEqual(node[0], KeyPointValue(
             index=7, value=30.0, name='Groundspeed With Thrust Reversers Deployed Any Power Min'))

--- a/tests/multistate_parameters_test.py
+++ b/tests/multistate_parameters_test.py
@@ -3848,6 +3848,23 @@ class TestThrustReversers(unittest.TestCase):
                                 eng_2_unlocked] + [None] * 21)
         np.testing.assert_equal(self.thrust_reversers.array.data, result)
 
+    def test_derive_reversers_multistate(self):
+        values_mapping = {0: 'Stowed', 1: 'In Transit', 2: 'Deployed'}
+        e1_status = M(
+            'Eng (1) Thrust Reverser',
+            array=np.ma.repeat((0, 1, 2, 1, 0), (10, 3, 5, 3, 10)),
+            values_mapping=values_mapping
+        )
+        e2_status = M(
+            'Eng (2) Thrust Reverser',
+            array=np.ma.repeat((0, 1, 2, 1, 0), (9, 3, 5, 3, 11)),
+            values_mapping=values_mapping
+        )
+        self.thrust_reversers.derive(*[None] * 28, e1_status, e2_status, None, None)
+
+        expected = np.ma.repeat((0, 1, 2, 1, 0), (9, 4, 4, 4, 10))
+        ma_test.assert_array_equal(self.thrust_reversers.array.raw, expected)
+
 
 class TestTakeoffConfigurationWarning(unittest.TestCase):
 


### PR DESCRIPTION
Thrust Reversers show spurious Deployed during engine start or stop.