### PR TITLE
AE-2590 Fix bug with Flap Lever masked values

### DIFF
--- a/analysis_engine/key_point_values.py
+++ b/analysis_engine/key_point_values.py
@@ -5973,26 +5973,29 @@ class AltitudeAtLastFlapChangeBeforeBottomOfDescent(KeyPointValueNode):
         ]
 
         for bottom in bottoms_in_app:
-            endpoint = bottom.index
+            endpoint = int(bottom.index)
             if far:
                 # This is an aircraft with automatic flap retraction. If the
                 # auto retraction happened within three seconds of the
                 # bottom of descent, set the endpoint to three seconds before the
                 # bottom of descent.
                 delta = int(3 * flap.hz)
-                if far.array.raw[int(endpoint - delta)] == 0 and \
-                        far.array.raw[int(endpoint + delta)] == 1:
+                if far.array.raw[endpoint - delta] == 0 and \
+                        far.array.raw[endpoint + delta] == 1:
                     endpoint = endpoint - delta
 
-            final_flap = flap.array.raw[int(endpoint)]
+            final_flap = flap.array.raw[endpoint]
             flap_move = abs(flap.array.raw - final_flap)
-            rough_index = index_at_value(flap_move, 0.5, slice(endpoint, 0, -1))
-            # index_at_value tries to be precise, but in this case we really
-            # just want the index at the new flap setting.
-            if rough_index:
-                last_index = np.round(rough_index)
-                alt_last = value_at_index(alt_aal.array, last_index)
-                self.create_kpv(last_index, alt_last)
+            # First non zero value is where the flaps were at a different setting
+            first_flap_move = np.ma.argmax(flap_move[endpoint:0:-1] != 0.0)
+            if not first_flap_move:
+                # Flap never moved?
+                continue
+            index = endpoint - first_flap_move + 1
+            if index:
+                alt_last = value_at_index(alt_aal.array, index)
+                if alt_last is not None:
+                    self.create_kpv(index, alt_last)
 
 
 class AltitudeAtLastFlapSelectionBeforeTouchdown(KeyPointValueNode):

--- a/tests/key_point_value_test.py
+++ b/tests/key_point_value_test.py
@@ -7357,6 +7357,23 @@ class TestAltitudeAtLastFlapChangeBeforeBottomOfDescent(unittest.TestCase, NodeT
         ]))
 
 
+    def test_masked_flap_lever(self):
+        array = np.ma.concatenate((np.ones(8) * 10, np.ones(7) * 15))
+        array[4:8] = np.ma.masked
+        mapping = {0: '0', 10: '10', 15: '15'}
+        flap_lever = M(name='Flap Lever', array=array, values_mapping=mapping)
+        array = np.ma.concatenate((np.arange(1000, 0, -100), np.zeros(5)))
+        alt_aal = P(name='Altitude AAL', array=array)
+        bottoms = KTI('Bottom Of Descent', items=[KeyTimeInstance(10)])
+        apps = buildsection('Approach And Landing', 0, 15)
+        name = self.node_class.get_name()
+        node = self.node_class()
+        node.derive(alt_aal, flap_lever, None, bottoms, apps, None)
+        self.assertEqual(node, KPV(name=name, items=[
+            KeyPointValue(index=4.0, value=600.0, name=name),
+        ]))
+
+
 class TestAltitudeAtLastFlapSelectionBeforeTouchdown(unittest.TestCase):
     def setUp(self):
         self.node_class = AltitudeAtLastFlapSelectionBeforeTouchdown


### PR DESCRIPTION
Masked flap lever could prevent the correct determination of the last
flap lever change. We now look for the last different flap lever position.