### PR TITLE
bugfix/DJ/AE-2884_WCO_N246CH - Trap for wholly masked speed array case.

### DIFF
--- a/analysis_engine/split_hdf_to_segments.py
+++ b/analysis_engine/split_hdf_to_segments.py
@@ -192,7 +192,7 @@ def _segment_type_and_slice(speed_array, speed_frequency,
                     col_start -= col_window_sample + np.ma.where(col.array[col_start - col_window_sample:col_start])[0][0]
                 except IndexError:
                     pass
-                if col_start < unmasked_slices[0].start:
+                if unmasked_slices and col_start < unmasked_slices[0].start:
                     col_start = unmasked_slices[0].start
                 try: # shift stop forwards to later low Collective value
                     col_stop += np.ma.where(col.array[col_stop:col_stop + col_window_sample])[0][-1]


### PR DESCRIPTION
This aircraft generates short segments with practically all speed_array values masked, which leads to a failure at unmasked_slices[0].