### PR TITLE
Bugfix/ja/ae 2791

### DIFF
--- a/analysis_engine/approaches.py
+++ b/analysis_engine/approaches.py
@@ -122,7 +122,7 @@ class ApproachInformation(ApproachNode):
 
     def _evaluate_airports(self, airports, lowest_lat, lowest_lon, lowest_hdg, appr_ils_freq):
         '''
-        pre filter cirteria on airprots
+        Pre-filter criteria on airports
         '''
         annotated_airports = {}
         for airport in airports:

--- a/tests/test_data/airports.yaml
+++ b/tests/test_data/airports.yaml
@@ -3140,6 +3140,42 @@ nice:
       length: 9711
       surface: ASP
       width: 147
+  - end:
+      elevation: 10
+      latitude: 43.64675556544192
+      longitude: 7.202516309192618
+    id: 4450
+    identifier: 22L
+    localizer:
+      is_offset: false
+    magnetic_heading: 223.0
+    start:
+      elevation: 12
+      latitude: 43.66559047553922
+      longitude: 7.228417347221212
+    strip:
+      id: 2225
+      length: 9711
+      surface: ASP
+      width: 147
+  - end:
+      elevation: 10
+      latitude: 43.65183018951411
+      longitude: 7.204073999999882
+    id: 4452
+    identifier: 22R
+    localizer:
+      is_offset: false
+    magnetic_heading: 223.0
+    start:
+      elevation: 10
+      latitude: 43.66815933411522
+      longitude: 7.226522991401687
+    strip:
+      id: 2226
+      length: 8432
+      surface: ASP
+      width: 147
 palma_de_mallorca:
   code:
     iata: PMI


### PR DESCRIPTION
FlightAttributes for Takeoff and Landing airports/runways has been updated
but ApproachInformation need to use the same logic to adjust the smoothed
lat/lon appropriately.

The logic goes like:
    For the airport:

    1. Find the nearest airport to the coordinates at landing with precise positioning.
    2. Use the airport data provided in the achieved flight record if the aircraft
       does not have precise positioning.
    3. Find the nearest airport to the coordinates at landing without precise
       positioning.
    4. Use the airport data provided in the achieved flight record as a fallback.

    For the runway:

    1. Use the runway data provided in the achieved flight record if available and
       the aircraft does not have precise positioning.
    2. Using airport, heading and coordinates at landing.
    3. Use the runway data provided in the achieved flight record if heading is
       missing or the runway failed to derive.

Refactored a bit the _lookup_airport_and_runway to conform to this new logic.
Broke down the airport determination in its own function.