### PR TITLE
Bugfix/dj/ae 2969 failure of engine running algorithm

### DIFF
--- a/analysis_engine/multistate_parameters.py
+++ b/analysis_engine/multistate_parameters.py
@@ -983,11 +983,11 @@ class EngRunning(object):
             # Ideally have N2 and Fuel Flow with both available,
             # otherwise use just one source
             n2_running = eng_n2.array > MIN_CORE_RUNNING if eng_n2 \
-                else np.zeros_like(fuel_flow.array, dtype=bool)
+                else np.ones_like(fuel_flow.array, dtype=bool)
             fuel_flowing = fuel_flow.array > MIN_FUEL_FLOW_RUNNING if fuel_flow \
-                else np.zeros_like(eng_n2.array, dtype=bool)
+                else np.ones_like(eng_n2.array, dtype=bool)
             # data only considered if not masked
-            data = (n2_running.data & ~n2_running.mask) & (fuel_flowing.data & ~fuel_flowing.mask)
+            data = (n2_running.data | n2_running.mask) & (fuel_flowing.data | fuel_flowing.mask)
             mask = n2_running.mask & fuel_flowing.mask
             return np.ma.where(np.ma.array(data, mask=mask), 'Running', 'Not Running')
         else:

--- a/analysis_engine/multistate_parameters.py
+++ b/analysis_engine/multistate_parameters.py
@@ -987,7 +987,7 @@ class EngRunning(object):
             fuel_flowing = fuel_flow.array > MIN_FUEL_FLOW_RUNNING if fuel_flow \
                 else np.zeros_like(eng_n2.array, dtype=bool)
             # data only considered if not masked
-            data = (n2_running.data & ~n2_running.mask) | (fuel_flowing.data & ~fuel_flowing.mask)
+            data = (n2_running.data & ~n2_running.mask) & (fuel_flowing.data & ~fuel_flowing.mask)
             mask = n2_running.mask & fuel_flowing.mask
             return np.ma.where(np.ma.array(data, mask=mask), 'Running', 'Not Running')
         else:

--- a/tests/multistate_parameters_test.py
+++ b/tests/multistate_parameters_test.py
@@ -1239,22 +1239,23 @@ class TestEng_AllRunning(unittest.TestCase):
         self.assertEqual(node.array.raw.tolist(), expected)
 
     def test_derive_n2_ff(self):
-        n2_array = np.ma.array([0, 5, 11, 15, 11, 5, 0])
+        n2_array = np.ma.array([0, 15, 11, 15, 11, 5, 0])
         n2 = P('Eng (*) N2 Min', array=n2_array)
-        ff_array = np.ma.array([10, 20, 50, 55, 51, 51, 10])
+        ff_array = np.ma.array([0, 0, 51, 55, 51, 51, 0])
         ff = P('Eng (*) Fuel Flow Min', array=ff_array)
-        expected = [False, False, True, True, True, True, False]
+        expected = [False, False, True, True, True, False, False]
         node = self.node_class()
         node.derive(None, n2, None, ff)
         self.assertEqual(node.array.raw.tolist(), expected)
 
     def test_derive_n2_ff_masked_values(self):
-        n2_array = np.ma.array([0, 5, 11, 15, 11, 5, 0])
-        n2_array[2] = np.ma.masked
+        n2_array = np.ma.array([0, 15, 11, 15, 11, 5, 0])
+        n2_array[2:4] = np.ma.masked
         n2 = P('Eng (*) N2 Min', array=n2_array)
-        ff_array = np.ma.array([10, 20, 50, 55, 51, 51, 10])
+        ff_array = np.ma.array([0, 0, 51, 55, 51, 51, 0])
+        ff_array[4:6] = np.ma.masked
         ff = P('Eng (*) Fuel Flow Min', array=ff_array)
-        expected = [False, False, False, True, True, True, False]
+        expected = [False, False, True, True, True, False, False]
         node = self.node_class()
         node.derive(None, n2, None, ff)
         self.assertEqual(node.array.raw.tolist(), expected)
@@ -1308,11 +1309,11 @@ class TestEng_AnyRunning(unittest.TestCase):
         self.assertEqual(node.array.raw.tolist(), expected)
 
     def test_derive_n2_ff(self):
-        n2_array = np.ma.array([0, 5, 11, 15, 11, 5, 0])
+        n2_array = np.ma.array([0, 15, 21, 15, 11, 5, 0])
         n2 = P('Eng (*) N2 Max', array=n2_array)
-        ff_array = np.ma.array([10, 20, 50, 55, 51, 51, 10])
+        ff_array = np.ma.array([0, 0, 51, 55, 51, 51, 10])
         ff = P('Eng (*) Fuel Flow Max', array=ff_array)
-        expected = [False, False, True, True, True, True, False]
+        expected = [False, False, True, True, True, False, False]
         node = self.node_class()
         node.derive(None, n2, None, ff)
         self.assertEqual(node.array.raw.tolist(), expected)


### PR DESCRIPTION
On behalf of DJ:
Implemented as requested, and checked using the two cases cited in the ticket.